### PR TITLE
Fixed bug: configuration loader should return an error when trying to

### DIFF
--- a/configuration_loader/configuration_loader.go
+++ b/configuration_loader/configuration_loader.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"strconv"
 	"strings"
 	"time"
 
@@ -65,6 +66,20 @@ func loadConfigurationFromFileContent(fileContent []byte) (result InitialConfigu
 			}
 			if result.GRPCServerIp != "" {
 				err = errors.New("Configuration should only contain one of telegram bot configuration or gRPC configuration")
+			}
+		}
+		if len(result.AutomaticMessages) > 0 {
+			for index, automaticMessage := range result.AutomaticMessages {
+				found := false
+				for _, pin := range result.PinsActive {
+					if pin.Name == automaticMessage.Action.Pin {
+						found = true
+						break
+					}
+				}
+				if !found {
+					err = errors.New("Automatic message number " + strconv.Itoa(index) + ", " + automaticMessage.Action.Pin + " not present in the pins active")
+				}
 			}
 		}
 	}

--- a/configuration_loader/configuration_loader_test.go
+++ b/configuration_loader/configuration_loader_test.go
@@ -120,6 +120,38 @@ func TestLoadClientConfigurationFromStringWithCorrectTelegramBotData(t *testing.
 
 }
 
+func TestLoadClientConfigurationFromStringWithWrongAutomaticMessages(t *testing.T) {
+	content := []byte(`
+	{
+		"GRPCServerIp": "192.168.2.160:8000",
+		"PinsActive": [
+			{
+				"name": "light",
+				"pin": 	18
+			}
+		],
+		"AutomaticMessages": [
+			{
+				"Action": {
+					"Pin": "water",
+					"State": true
+				},
+				"Time": "03:45:10"
+			},
+			{
+				"Action": {
+					"Pin": "water",
+					"State": false
+				},
+				"Time": "03:45:15"
+			}
+		]
+	}`)
+	if _, err := loadConfigurationFromFileContent(content); err == nil {
+		t.Errorf("loadConfigurationFromFileContent() with automatic messages to pins not present in the gpio manager should return an error")
+	}
+}
+
 func TestLoadClientConfigurationFromStringWithCorrectGRPCData(t *testing.T) {
 	content := []byte(`
 	{


### PR DESCRIPTION
load an automatic message not set in pins active